### PR TITLE
Make generators work properly

### DIFF
--- a/test/test_generators.py
+++ b/test/test_generators.py
@@ -10,26 +10,42 @@ async def async_producer(events):
         yield i
 
 
-async def async_consumer(producer, events):
-    async for i in producer:
+@pytest.mark.asyncio
+async def test_generator_order_async():
+    events = []
+    async_producer_synchronized = Synchronizer()(async_producer)
+    async for i in async_producer_synchronized(events):
         events.append("consumer")
+    assert events == ["producer", "consumer"] * 10
 
 
-def sync_consumer(producer, events):
-    for i in producer:
+def test_generator_order_sync():
+    events = []
+    async_producer_synchronized = Synchronizer()(async_producer)
+    for i in async_producer_synchronized(events):
         events.append("consumer")
+    assert events == ["producer", "consumer"] * 10
+
+
+async def async_bidirectional_producer(i):
+    j = yield i
+    assert j == i**2
 
 
 @pytest.mark.asyncio
-async def test_generator_order_async_async():
-    events = []
-    async_producer_synchronized = Synchronizer()(async_producer)
-    await async_consumer(async_producer_synchronized(events), events)
-    assert events == ["producer", "consumer"] * 10
+async def test_bidirectional_generator_async():
+    f = Synchronizer()(async_bidirectional_producer)
+    gen = f(42)
+    value = await gen.asend(None)
+    assert value == 42
+    with pytest.raises(StopAsyncIteration):
+        await gen.asend(42*42)
 
 
-def test_generator_order_async_sync():
-    events = []
-    async_producer_synchronized = Synchronizer()(async_producer)
-    sync_consumer(async_producer_synchronized(events), events)
-    assert events == ["producer", "consumer"] * 10
+def test_bidirectional_generator_sync():
+    f = Synchronizer()(async_bidirectional_producer)
+    gen = f(42)
+    value = gen.send(None)
+    assert value == 42
+    with pytest.raises(StopIteration):
+        gen.send(42*42)

--- a/test/test_generators.py
+++ b/test/test_generators.py
@@ -1,0 +1,35 @@
+import asyncio
+import pytest
+
+from synchronicity import Synchronizer
+
+
+async def async_producer(events):
+    for i in range(10):
+        events.append("producer")
+        yield i
+
+
+async def async_consumer(producer, events):
+    async for i in producer:
+        events.append("consumer")
+
+
+def sync_consumer(producer, events):
+    for i in producer:
+        events.append("consumer")
+
+
+@pytest.mark.asyncio
+async def test_generator_order_async_async():
+    events = []
+    async_producer_synchronized = Synchronizer()(async_producer)
+    await async_consumer(async_producer_synchronized(events), events)
+    assert events == ["producer", "consumer"] * 10
+
+
+def test_generator_order_async_sync():
+    events = []
+    async_producer_synchronized = Synchronizer()(async_producer)
+    sync_consumer(async_producer_synchronized(events), events)
+    assert events == ["producer", "consumer"] * 10


### PR DESCRIPTION
This actually ended up being substantially _simpler_ than the existing code, although with tests it's a net positive diff.

The problem was that we'd previously push generators into an unbounded queue, disregarding the consumer. The proper generator protocol in Python is to exchange control back and forth between the producer and the consumer. This happens now.

This also adds support for _sending_ values into generator, which previously wasn't supported.