### PR TITLE
Force sync/async call behavior

### DIFF
--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -109,30 +109,25 @@ class Synchronizer:
     def _wrap_callable(self, f, return_future=None):
         def f_sync(*args, **kwargs):
             res = f(*args, **kwargs)
-            is_coroutine = inspect.iscoroutine(res)
-            is_asyncgen = inspect.isasyncgen(res)
-            if is_coroutine:
+            if inspect.iscoroutine(res):
                 return self._run_function_sync(res, return_future=return_future)
-            elif is_asyncgen:
+            elif inspect.isasyncgen(res):
                 return self._run_generator_sync(res)
             else:
                 return res
 
         def f_async(*args, **kwargs):
             res = f(*args, **kwargs)
-            is_coroutine = inspect.iscoroutine(res)
-            is_asyncgen = inspect.isasyncgen(res)
-            if is_coroutine:
+            if inspect.iscoroutine(res):
                 return self._run_function_async(res)
-            elif is_asyncgen:
+            elif inspect.isasyncgen(res):
                 return self._run_generator_async(res)
             else:
                 return res
 
         @functools.wraps(f)
         def f_wrapped(*args, **kwargs):
-            is_async_context = self._is_async_context()
-            if is_async_context:
+            if self._is_async_context():
                 return f_async(*args, **kwargs)
             else:
                 return f_sync(*args, **kwargs)

--- a/test/test_synchronicity.py
+++ b/test/test_synchronicity.py
@@ -388,3 +388,21 @@ def test_event_loop():
     with pytest.raises(Exception):
         s._start_loop(new_loop)
 
+
+@pytest.mark.asyncio
+async def test_call_explicit_from_async():
+    s = Synchronizer()
+    f_s = s(f)
+    assert await f_s(42) == 1764  # Default, detect context
+    assert await f_s.call_async(42) == 1764  # Force async
+    assert f_s.call_sync(42) == 1764  # Force sync
+
+
+def test_call_explicit_from_sync():
+    s = Synchronizer()
+    f_s = s(f)
+    assert f_s(42) == 1764  # Default, detect context
+    coro = f_s.call_async(42)  # Force async
+    assert inspect.iscoroutine(coro)
+    assert asyncio.run(coro) == 1764
+    assert f_s.call_sync(42) == 1764  # Force sync


### PR DESCRIPTION
This just makes it possible in user code to force certain behavior. It's not necessarily super useful in itself. The next step is to rewrite the `return_futures` stuff so that it's not a synchronizer-wide setting but rather a separate function call. That way the idea is if you have a synchronized function `f(x)` then

* `f(x)` will infer sync/async behavior from the context
* `f.call_sync(x)` will always block
* `f.call_async(x)` will always return a coroutine
* `f.defer(x)` will return a `Future` which is thread-safe and can be used in an async or sync context

The last one doesn't exist yet, that's the subsequent thing.