### PR TITLE
Fix something with exception contexts

### DIFF
--- a/synchronicity/contextlib.py
+++ b/synchronicity/contextlib.py
@@ -60,13 +60,13 @@ class AsyncGeneratorContextManager:
         try:
             return await self.synchronizer._run_function_async(self._enter())
         except UserCodeException as uc_exc:
-            raise uc_exc.exc
+            raise uc_exc.exc from None
 
     def __enter__(self):
         try:
             return self.synchronizer._run_function_sync(self._enter(), False)
         except UserCodeException as uc_exc:
-            raise uc_exc.exc
+            raise uc_exc.exc from None
 
     async def __aexit__(self, typ, value, traceback):
         try:
@@ -74,7 +74,7 @@ class AsyncGeneratorContextManager:
                 self._exit(typ, value, traceback)
             )
         except UserCodeException as uc_exc:
-            raise uc_exc.exc
+            raise uc_exc.exc from None
 
     def __exit__(self, typ, value, traceback):
         try:
@@ -82,4 +82,4 @@ class AsyncGeneratorContextManager:
                 self._exit(typ, value, traceback), False
             )
         except UserCodeException as uc_exc:
-            raise uc_exc.exc
+            raise uc_exc.exc from None

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -112,7 +112,7 @@ class Synchronizer:
                         gen.asend(value), return_future=False
                     )
             except UserCodeException as uc_exc:
-                raise uc_exc.exc
+                raise uc_exc.exc from None
             except StopAsyncIteration:
                 break
             try:
@@ -136,7 +136,7 @@ class Synchronizer:
                     )
             except UserCodeException as uc_exc:
                 if unwrap_user_excs:
-                    raise uc_exc.exc
+                    raise uc_exc.exc from None
                 else:
                     # This is needed since contextlib uses this function as a helper
                     raise uc_exc
@@ -164,14 +164,14 @@ class Synchronizer:
                         try:
                             return await coro
                         except UserCodeException as uc_exc:
-                            raise uc_exc.exc
+                            raise uc_exc.exc from None
 
                     return unwrap_exc()
                 else:
                     try:
                         return self._run_function_sync(res, return_future)
                     except UserCodeException as uc_exc:
-                        raise uc_exc.exc
+                        raise uc_exc.exc from None
             elif is_asyncgen:
                 if is_async_context:
                     return self._run_generator_async(res)


### PR DESCRIPTION
There's an annoying error in the current main which triggers complicated exceptions like

```
Traceback (most recent call last):
  File "/Users/erikbern/synchronicity/synchronicity/contextlib.py", line 67, in __enter__
    return self.synchronizer._run_function_sync(self._enter(), False)
  File "/Users/erikbern/synchronicity/synchronicity/synchronizer.py", line 89, in _run_function_sync
    return fut.result()
  File "/Users/erikbern/miniforge3/lib/python3.9/concurrent/futures/_base.py", line 440, in result
    return self.__get_result()
  File "/Users/erikbern/miniforge3/lib/python3.9/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
  File "/Users/erikbern/synchronicity/synchronicity/exceptions.py", line 23, in coro_wrapped
    raise exc  # Pass-through in case it got double-wrapped
  File "/Users/erikbern/synchronicity/synchronicity/exceptions.py", line 19, in coro_wrapped
    return await coro
  File "/Users/erikbern/synchronicity/synchronicity/contextlib.py", line 22, in _enter
    return await self.gen.__anext__()
  File "/Users/erikbern/synchronicity/synchronicity/synchronizer.py", line 142, in _run_generator_async
    raise uc_exc
  File "/Users/erikbern/synchronicity/synchronicity/synchronizer.py", line 134, in _run_generator_async
    value = await self._run_function_async(
  File "/Users/erikbern/synchronicity/synchronicity/synchronizer.py", line 95, in _run_function_async
    return await coro
  File "/Users/erikbern/synchronicity/synchronicity/exceptions.py", line 25, in coro_wrapped
    raise UserCodeException(exc)
synchronicity.exceptions.UserCodeException: Connecting to http://banana.xyz: failed to connect to all addresses

During handling of the above exception, another exception occurred:

```
and then the real exception

Adding `from None` fixes this. I don't know what's going on but I think it has to do with https://www.python.org/dev/peps/pep-0409/

Unfortunately I'm not sure how to test this?