### PR TITLE
Try to identify async leakage

### DIFF
--- a/test/warnings_test.py
+++ b/test/warnings_test.py
@@ -1,3 +1,4 @@
+import inspect
 import warnings
 
 from synchronicity import Synchronizer
@@ -24,3 +25,19 @@ def test_multiwrap_no_warning(recwarn):
     f_s_s = s(f_s)
     assert f_s_s(42) == 1764
     assert len(recwarn) == 0
+
+
+async def asyncgen():
+    yield 42
+
+
+async def returns_asyncgen():
+    return asyncgen()
+
+
+def test_check_double_wrapped(recwarn):
+    s = Synchronizer()
+    assert len(recwarn) == 0
+    ret = s(returns_asyncgen)()
+    assert inspect.isasyncgen(ret)
+    assert len(recwarn) == 1


### PR DESCRIPTION
This will warn if there's "async leakage" in the code. Leakage here means that a coroutine function returns another coroutine, or an async generators. This is bad because the caller might be in a sync context, or in an async context but with a different loop. Getting back an async object in that case might lead to bad problems.

coroutines returning a coroutine can always be trivially refactored into just a simple coroutine.

coroutines returning an async generator might be harder to refactor, but I think it's generally quite bad since it leads to awkward code of the form `async for x in await f()`.

Up until #25, this was masked to some extent because we allowed functions to be doubly synchronized. 