### PR TITLE
Lots of stack trace junk for intra-loop calls

### DIFF
--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -165,13 +165,9 @@ class Synchronizer:
         while True:
             try:
                 if is_exc:
-                    value = await self._run_function_async(
-                        wrap_coro_exception(gen.athrow(value))
-                    )
+                    value = await self._run_function_async(gen.athrow(value))
                 else:
-                    value = await self._run_function_async(
-                        wrap_coro_exception(gen.asend(value))
-                    )
+                    value = await self._run_function_async(gen.asend(value))
             except UserCodeException as uc_exc:
                 if unwrap_user_excs:
                     raise uc_exc.exc from None

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -201,6 +201,11 @@ class Synchronizer:
                 # The run_function_* may throw UserCodeExceptions that
                 # need to be unwrapped here at the entrypoint
                 if is_async_context:
+                    if self._get_running_loop() == self._get_loop():
+                        # See #27. This is a bit of a hack needed to "shortcut" the exception
+                        # handling if we're within the same loop - there's no need to wrap and
+                        # unwrap the exception and it just adds unnecessary traceback spam.
+                        return res
                     coro = self._run_function_async(res)
                     coro = unwrap_coro_exception(coro)
                     return coro

--- a/test/tracebacks_test.py
+++ b/test/tracebacks_test.py
@@ -96,3 +96,18 @@ async def test_async_to_async_ctx_mgr():
         async with ctx_mgr():
             pass
     check_traceback(excinfo.value)
+
+
+def test_recursive():
+    s = Synchronizer()
+
+    @s
+    async def f(n):
+        if n == 0:
+            raise CustomException("boom!")
+        else:
+            return await f(n-1)
+
+    with pytest.raises(CustomException) as excinfo:
+        f(10)
+    check_traceback(excinfo.value)


### PR DESCRIPTION
This is just a test that reproduces it. Outputs the following:

```
----------------------------------------------------------------------- Captured stdout call -----------------------------------------------------------------------
/Users/erikbern/synchronicity/test/tracebacks_test.py 100 f(10)
/Users/erikbern/synchronicity/synchronicity/synchronizer.py 215 raise uc_exc.exc from None
/Users/erikbern/synchronicity/test/tracebacks_test.py 97 return await f(n-1)
/Users/erikbern/synchronicity/synchronicity/exceptions.py 31 raise uc_exc.exc from None
/Users/erikbern/synchronicity/test/tracebacks_test.py 97 return await f(n-1)
/Users/erikbern/synchronicity/synchronicity/exceptions.py 31 raise uc_exc.exc from None
/Users/erikbern/synchronicity/test/tracebacks_test.py 97 return await f(n-1)
/Users/erikbern/synchronicity/synchronicity/exceptions.py 31 raise uc_exc.exc from None
/Users/erikbern/synchronicity/test/tracebacks_test.py 97 return await f(n-1)
/Users/erikbern/synchronicity/synchronicity/exceptions.py 31 raise uc_exc.exc from None
/Users/erikbern/synchronicity/test/tracebacks_test.py 97 return await f(n-1)
/Users/erikbern/synchronicity/synchronicity/exceptions.py 31 raise uc_exc.exc from None
/Users/erikbern/synchronicity/test/tracebacks_test.py 97 return await f(n-1)
/Users/erikbern/synchronicity/synchronicity/exceptions.py 31 raise uc_exc.exc from None
/Users/erikbern/synchronicity/test/tracebacks_test.py 97 return await f(n-1)
/Users/erikbern/synchronicity/synchronicity/exceptions.py 31 raise uc_exc.exc from None
/Users/erikbern/synchronicity/test/tracebacks_test.py 97 return await f(n-1)
/Users/erikbern/synchronicity/synchronicity/exceptions.py 31 raise uc_exc.exc from None
/Users/erikbern/synchronicity/test/tracebacks_test.py 97 return await f(n-1)
/Users/erikbern/synchronicity/synchronicity/exceptions.py 31 raise uc_exc.exc from None
/Users/erikbern/synchronicity/test/tracebacks_test.py 97 return await f(n-1)
/Users/erikbern/synchronicity/synchronicity/exceptions.py 31 raise uc_exc.exc from None
/Users/erikbern/synchronicity/test/tracebacks_test.py 95 raise CustomException("boom!")
===================================================================== short test summary info ======================================================================
FAILED test/tracebacks_test.py::test_recursive - Exception: Got 11 frames outside user code, expected 1
```