### PR TITLE
return_future as a property of each call

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,19 +126,19 @@ data = db_conn.query('select * from foo')
 Returning futures
 -----------------
 
-You can also make it return a `Future` object by instantiating the `Synchronizer` class with `return_futures=True`. This can be useful if you want to dispatch many calls from a blocking context, but you want to resolve them roughly in parallel:
+You can also make functions return a `Future` object by adding `_future=True` to any call. This can be useful if you want to dispatch many calls from a blocking context, but you want to resolve them roughly in parallel:
 
 ```python
 from synchronicity import Synchronizer
 
-synchronizer = Synchronizer(return_futures=True)
+synchronizer = Synchronizer()
 
 @synchronizer
 async def f(x):
     await asyncio.sleep(1.0)
     return x**2
 
-futures = [f(i) for i in range(10)]  # This returns immediately
+futures = [f(i, _future=True) for i in range(10)]  # This returns immediately
 rets = [fut.result() for fut in futures]  # This should take ~1s to run, resolving all futures in parallel
 print('first ten squares:', rets)
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup(name="synchronicity", version="0.1.4")
+setup(name="synchronicity", version="0.1.5")

--- a/synchronicity/contextlib.py
+++ b/synchronicity/contextlib.py
@@ -64,9 +64,11 @@ class AsyncGeneratorContextManager:
 
     def __enter__(self):
         if self.synchronizer._is_async_context():
-            raise RuntimeError("Attempt to use 'with' in async code. Did you mean 'async with'?")
+            raise RuntimeError(
+                "Attempt to use 'with' in async code. Did you mean 'async with'?"
+            )
         try:
-            return self.synchronizer._run_function_sync(self._enter(), False)
+            return self.synchronizer._run_function_sync(self._enter())
         except UserCodeException as uc_exc:
             raise uc_exc.exc from None
 
@@ -79,7 +81,7 @@ class AsyncGeneratorContextManager:
     def __exit__(self, typ, value, traceback):
         try:
             return self.synchronizer._run_function_sync(
-                self._exit(typ, value, traceback), False
+                self._exit(typ, value, traceback)
             )
         except UserCodeException as uc_exc:
             raise uc_exc.exc from None

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -29,11 +29,11 @@ def test_function_sync():
 
 
 def test_function_sync_future():
-    s = Synchronizer(return_futures=True)
+    s = Synchronizer()
     t0 = time.time()
     f_s = s(f)
     assert f_s.__name__ == "f"
-    fut = f_s(42)
+    fut = f_s(42, _future=True)
     assert isinstance(fut, concurrent.futures.Future)
     assert time.time() - t0 < SLEEP_DELAY
     assert fut.result() == 1764
@@ -92,10 +92,10 @@ def test_function_many_parallel_sync():
 
 
 def test_function_many_parallel_sync_futures():
-    s = Synchronizer(return_futures=True)
+    s = Synchronizer()
     g = s(f)
     t0 = time.time()
-    futs = [g(i) for i in range(100)]
+    futs = [g(i, _future=True) for i in range(100)]
     assert isinstance(futs[0], concurrent.futures.Future)
     assert time.time() - t0 < SLEEP_DELAY
     assert [fut.result() for fut in futs] == [z ** 2 for z in range(100)]
@@ -133,10 +133,10 @@ def test_function_raises_sync():
 
 
 def test_function_raises_sync_futures():
-    s = Synchronizer(return_futures=True)
+    s = Synchronizer()
     t0 = time.time()
     f_raises_s = s(f_raises)
-    fut = f_raises_s()
+    fut = f_raises_s(_future=True)
     assert isinstance(fut, concurrent.futures.Future)
     assert time.time() - t0 < SLEEP_DELAY
     with pytest.raises(CustomException):
@@ -231,10 +231,10 @@ def test_sync_lambda_returning_coroutine_sync():
 
 
 def test_sync_lambda_returning_coroutine_sync_futures():
-    s = Synchronizer(return_futures=True)
+    s = Synchronizer()
     t0 = time.time()
     g = s(lambda z: f(z + 1))
-    fut = g(42)
+    fut = g(42, _future=True)
     assert isinstance(fut, concurrent.futures.Future)
     assert time.time() - t0 < SLEEP_DELAY
     assert fut.result() == 1849
@@ -326,7 +326,7 @@ def test_class_sync():
 
 
 def test_class_sync_futures():
-    s = Synchronizer(return_futures=True)
+    s = Synchronizer()
     NewClass = s(MyClass)
     assert NewClass.__name__ == "MyClass"
     obj = NewClass(x=42)
@@ -334,7 +334,7 @@ def test_class_sync_futures():
     assert isinstance(obj, Base)
     assert obj._x == 42
     obj.start()
-    fut = obj.get_result()
+    fut = obj.get_result(_future=True)
     assert isinstance(fut, concurrent.futures.Future)
     assert fut.result() == 1764
 


### PR DESCRIPTION
As a part of breaking up the interface, I wanted to clean up the futures interface first. This makes it possible to get a future back selectively on each call.

I initially tried to do this as a special attribute on every function, eg. `f.future(42)` instead `f(42)`. Unfortunately this messes with how `self` is injected into methods. Instead what I settled for is `f(42, _future=42)`.

I don't _love_ adding an extra argument here since it likely interferes with typing annotations. Synchronicity already kind of mess with them, but this exacerbates it a bit. I just can't think of a better way to do it right now, unfortunately. We can revisit this later.