### PR TITLE
Split interfaces into async vs blocking

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup(name="synchronicity", version="0.1.5")
+setup(name="synchronicity", version="0.1.6")

--- a/synchronicity/__init__.py
+++ b/synchronicity/__init__.py
@@ -1,1 +1,2 @@
+from .interface import Interface
 from .synchronizer import Synchronizer

--- a/synchronicity/contextlib.py
+++ b/synchronicity/contextlib.py
@@ -1,4 +1,5 @@
 from .exceptions import UserCodeException, unwrap_coro_exception
+from .interface import Interface
 
 
 class AsyncGeneratorContextManager:
@@ -63,7 +64,7 @@ class AsyncGeneratorContextManager:
         return coro
 
     def __enter__(self):
-        if self.synchronizer._is_async_context():
+        if self.synchronizer._get_interface() == Interface.ASYNC:
             raise RuntimeError(
                 "Attempt to use 'with' in async code. Did you mean 'async with'?"
             )

--- a/synchronicity/interface.py
+++ b/synchronicity/interface.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class Interface(enum.Enum):
+    AUTODETECT = enum.auto()
+    BLOCKING = enum.auto()
+    ASYNC = enum.auto()

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -9,8 +9,7 @@ import time
 import warnings
 
 from .contextlib import AsyncGeneratorContextManager
-from .exceptions import (UserCodeException, unwrap_coro_exception,
-                         wrap_coro_exception)
+from .exceptions import UserCodeException, unwrap_coro_exception, wrap_coro_exception
 from .interface import Interface
 
 _BUILTIN_ASYNC_METHODS = {
@@ -248,7 +247,9 @@ class Synchronizer:
             if k in _BUILTIN_ASYNC_METHODS:
                 k_sync = _BUILTIN_ASYNC_METHODS[k]
                 new_dict[k] = v
-                new_dict[k_sync] = self._wrap_callable(v, interface, allow_futures=False)
+                new_dict[k_sync] = self._wrap_callable(
+                    v, interface, allow_futures=False
+                )
             elif callable(v):
                 new_dict[k] = self._wrap_callable(v, interface)
             elif isinstance(v, staticmethod):
@@ -266,7 +267,9 @@ class Synchronizer:
         cls_name = cls.__name__
         cls_bases = (cls,)
         cls_dict = cls.__dict__
-        return self.create_class(interface, cls_metaclass, cls_name, cls_bases, cls_dict)
+        return self.create_class(
+            interface, cls_metaclass, cls_name, cls_bases, cls_dict
+        )
 
     def _wrap(self, object, interface):
         if inspect.isclass(object):

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -241,7 +241,7 @@ class Synchronizer:
         setattr(f_wrapped, _WRAPPED_ATTR, True)
         return f_wrapped
 
-    def create_class(self, interface, cls_metaclass, cls_name, cls_bases, cls_dict):
+    def create_class(self, cls_metaclass, cls_name, cls_bases, cls_dict, interface=Interface.AUTODETECT):
         new_dict = {}
         for k, v in cls_dict.items():
             if k in _BUILTIN_ASYNC_METHODS:
@@ -268,7 +268,7 @@ class Synchronizer:
         cls_bases = (cls,)
         cls_dict = cls.__dict__
         return self.create_class(
-            interface, cls_metaclass, cls_name, cls_bases, cls_dict
+            cls_metaclass, cls_name, cls_bases, cls_dict, interface
         )
 
     def _wrap(self, object, interface):

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -9,7 +9,8 @@ import time
 import warnings
 
 from .contextlib import AsyncGeneratorContextManager
-from .exceptions import UserCodeException, wrap_coro_exception, unwrap_coro_exception
+from .exceptions import (UserCodeException, unwrap_coro_exception,
+                         wrap_coro_exception)
 from .interface import Interface
 
 _BUILTIN_ASYNC_METHODS = {

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -28,11 +28,9 @@ class Synchronizer:
 
     def __init__(
         self,
-        interface=Interface.AUTODETECT,
         multiwrap_warning=False,
         async_leakage_warning=True,
     ):
-        self._interface = interface
         self._multiwrap_warning = multiwrap_warning
         self._async_leakage_warning = async_leakage_warning
         self._loop = None
@@ -41,13 +39,11 @@ class Synchronizer:
 
     def __getstate__(self):
         return {
-            "_interface": self._interface,
             "_multiwrap_warning": self._multiwrap_warning,
             "_async_leakage_warning": self._async_leakage_warning,
         }
 
     def __setstate__(self, d):
-        self._interface = d["_interface"]
         self._multiwrap_warning = d["_multiwrap_warning"]
         self._async_leakage_warning = d["_async_leakage_warning"]
 
@@ -91,14 +87,13 @@ class Synchronizer:
             # Python 3.6 compatibility
             return asyncio._get_running_loop()
 
-    def _get_interface(self):
-        if self._interface == Interface.AUTODETECT:
-            if self._get_running_loop():
-                return Interface.ASYNC
-            else:
-                return Interface.BLOCKING
+    def _get_runtime_interface(self, interface):
+        """Returns one out of Interface.ASYNC or Interface.BLOCKING"""
+        if interface == Interface.AUTODETECT:
+            return Interface.ASYNC if self._get_running_loop() else Interface.BLOCKING
         else:
-            return self._interface
+            assert interface in (Interface.ASYNC, Interface.BLOCKING)
+            return interface
 
     def _wrap_check_async_leakage(self, coro):
         """Check if a coroutine returns another coroutine (or an async generator) and warn.
@@ -192,7 +187,7 @@ class Synchronizer:
                 value = exc
                 is_exc = True
 
-    def _wrap_callable(self, f, allow_futures=True):
+    def _wrap_callable(self, f, interface, allow_futures=True):
         if hasattr(f, _WRAPPED_ATTR):
             if self._multiwrap_warning:
                 warnings.warn(
@@ -204,13 +199,13 @@ class Synchronizer:
         def f_wrapped(*args, **kwargs):
             return_future = kwargs.pop(_RETURN_FUTURE_KWARG, False)
             res = f(*args, **kwargs)
-            interface = self._get_interface()
-            assert interface in [Interface.ASYNC, Interface.BLOCKING]
             is_coroutine = inspect.iscoroutine(res)
             is_asyncgen = inspect.isasyncgen(res)
+            runtime_interface = self._get_runtime_interface(interface)
+
             if return_future:
                 if not allow_futures:
-                    raise Exceptions("Can not return future for this function")
+                    raise Exception("Can not return future for this function")
                 elif is_coroutine:
                     return self._run_function_sync_future(res)
                 elif is_asyncgen:
@@ -220,7 +215,7 @@ class Synchronizer:
             elif is_coroutine:
                 # The run_function_* may throw UserCodeExceptions that
                 # need to be unwrapped here at the entrypoint
-                if interface == Interface.ASYNC:
+                if runtime_interface == Interface.ASYNC:
                     if self._get_running_loop() == self._get_loop():
                         # See #27. This is a bit of a hack needed to "shortcut" the exception
                         # handling if we're within the same loop - there's no need to wrap and
@@ -229,7 +224,7 @@ class Synchronizer:
                     coro = self._run_function_async(res)
                     coro = unwrap_coro_exception(coro)
                     return coro
-                elif interface == Interface.BLOCKING:
+                elif runtime_interface == Interface.BLOCKING:
                     try:
                         return self._run_function_sync(res)
                     except UserCodeException as uc_exc:
@@ -237,9 +232,9 @@ class Synchronizer:
             elif is_asyncgen:
                 # Note that the _run_generator_* functions handle their own
                 # unwrapping of exceptions (this happens during yielding)
-                if interface == Interface.ASYNC:
+                if runtime_interface == Interface.ASYNC:
                     return self._run_generator_async(res)
-                elif interface == Interface.BLOCKING:
+                elif runtime_interface == Interface.BLOCKING:
                     return self._run_generator_sync(res)
             else:
                 return res
@@ -247,43 +242,58 @@ class Synchronizer:
         setattr(f_wrapped, _WRAPPED_ATTR, True)
         return f_wrapped
 
-    def create_class(self, cls_metaclass, cls_name, cls_bases, cls_dict):
+    def create_class(self, interface, cls_metaclass, cls_name, cls_bases, cls_dict):
         new_dict = {}
         for k, v in cls_dict.items():
             if k in _BUILTIN_ASYNC_METHODS:
                 k_sync = _BUILTIN_ASYNC_METHODS[k]
                 new_dict[k] = v
-                new_dict[k_sync] = self._wrap_callable(v, allow_futures=False)
+                new_dict[k_sync] = self._wrap_callable(v, interface, allow_futures=False)
             elif callable(v):
-                new_dict[k] = self._wrap_callable(v)
+                new_dict[k] = self._wrap_callable(v, interface)
             elif isinstance(v, staticmethod):
                 # TODO(erikbern): this feels pretty hacky
-                new_dict[k] = staticmethod(self._wrap_callable(v.__func__))
+                new_dict[k] = staticmethod(self._wrap_callable(v.__func__, interface))
             elif isinstance(v, classmethod):
                 # TODO(erikbern): this feels pretty hacky
-                new_dict[k] = classmethod(self._wrap_callable(v.__func__))
+                new_dict[k] = classmethod(self._wrap_callable(v.__func__, interface))
             else:
                 new_dict[k] = v
         return type.__new__(cls_metaclass, cls_name, cls_bases, new_dict)
 
-    def _wrap_class(self, cls):
+    def _wrap_class(self, cls, interface):
         cls_metaclass = type
         cls_name = cls.__name__
         cls_bases = (cls,)
         cls_dict = cls.__dict__
-        return self.create_class(cls_metaclass, cls_name, cls_bases, cls_dict)
+        return self.create_class(interface, cls_metaclass, cls_name, cls_bases, cls_dict)
 
-    def __call__(self, object):
+    def _wrap(self, object, interface):
         if inspect.isclass(object):
-            return self._wrap_class(object)
+            return self._wrap_class(object, interface)
         elif callable(object):
-            return self._wrap_callable(object)
+            return self._wrap_callable(object, interface)
         else:
             raise Exception("Argument %s is not a class or a callable" % object)
 
-    def asynccontextmanager(self, func):
+    def wrap_async(self, object):
+        return self._wrap(object, Interface.ASYNC)
+
+    def wrap_blocking(self, object):
+        return self._wrap(object, Interface.BLOCKING)
+
+    def wrap_autodetect(self, object):
+        # TODO(erikbern): deprecate?
+        return self._wrap(object, Interface.AUTODETECT)
+
+    def __call__(self, object):
+        return self.wrap_autodetect(object)
+
+    def asynccontextmanager(self, func, interface=Interface.AUTODETECT):
+        # TODO(erikbern): enforce defining the interface type
+
         @functools.wraps(func)
         def helper(*args, **kwargs):
-            return AsyncGeneratorContextManager(self, func, args, kwargs)
+            return AsyncGeneratorContextManager(self, interface, func, args, kwargs)
 
         return helper

--- a/test/metaclass_test.py
+++ b/test/metaclass_test.py
@@ -1,39 +1,35 @@
 import asyncio
 import time
 
-from synchronicity import Synchronizer
+from synchronicity import Synchronizer, Interface
 
 SLEEP_DELAY = 0.1
 
-s = Synchronizer()
+def test_metaclass():
+    s = Synchronizer()
 
+    class ObjectMetaclass(type):
+        def __new__(metacls, name, bases, dct):
+            new_cls = s.create_class(Interface.BLOCKING, metacls, name, bases, dct)
+            return new_cls
 
-class ObjectMetaclass(type):
-    def __new__(metacls, name, bases, dct):
-        new_cls = s.create_class(metacls, name, bases, dct)
-        return new_cls
+    class ObjectBase(metaclass=ObjectMetaclass):
+        async def square(self, x):
+            await asyncio.sleep(SLEEP_DELAY)
+            return x ** 2
 
+    class ObjectDerived(ObjectBase):
+        async def cube(self, x):
+            await asyncio.sleep(SLEEP_DELAY)
+            return x ** 3
 
-class ObjectBase(metaclass=ObjectMetaclass):
-    async def square(self, x):
-        await asyncio.sleep(SLEEP_DELAY)
-        return x ** 2
-
-
-class ObjectDerived(ObjectBase):
-    async def cube(self, x):
-        await asyncio.sleep(SLEEP_DELAY)
-        return x ** 3
-
-
-def test_base():
+    # Test base class
     base = ObjectBase()
     t0 = time.time()
     assert base.square(42) == 42 * 42
     assert SLEEP_DELAY <= time.time() - t0 < 2 * SLEEP_DELAY
 
-
-def test_derived():
+    # Test subclass
     derived = ObjectDerived()
     t0 = time.time()
     assert derived.square(42) == 42 * 42

--- a/test/metaclass_test.py
+++ b/test/metaclass_test.py
@@ -10,7 +10,7 @@ def test_metaclass():
 
     class ObjectMetaclass(type):
         def __new__(metacls, name, bases, dct):
-            new_cls = s.create_class(Interface.BLOCKING, metacls, name, bases, dct)
+            new_cls = s.create_class(metacls, name, bases, dct)
             return new_cls
 
     class ObjectBase(metaclass=ObjectMetaclass):


### PR DESCRIPTION
This is a super crude starting point. Idea is to avoid the detection of async vs blocking, instead making it possible to specify it during wrapping.