### PR TITLE
new experimental api to mark classes/functions and get the interface later

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup(name="synchronicity", version="0.1.6")
+setup(name="synchronicity", version="0.1.7")

--- a/synchronicity/contextlib.py
+++ b/synchronicity/contextlib.py
@@ -17,9 +17,7 @@ class AsyncGeneratorContextManager:
 
         # Run it in the correct thread
         self._gen = synchronizer._run_generator_async(
-            func(*args, **kwargs),
-            self._interface,
-            unwrap_user_excs=False
+            func(*args, **kwargs), self._interface, unwrap_user_excs=False
         )
 
     async def _enter(self):

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -280,6 +280,11 @@ class Synchronizer:
                 new_dict[k_sync] = self._wrap_callable(
                     v, interface, allow_futures=False
                 )
+            elif k == "__new__":
+                # We leverage __new__ to translate between classes
+                # Wrapping this one creates an infinite recurision
+                # TODO(erikbern): feels hacky to ignore this one?
+                pass
             elif callable(v):
                 new_dict[k] = self._wrap_callable(v, interface)
             elif isinstance(v, staticmethod):

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -242,7 +242,16 @@ class Synchronizer:
                         # See #27. This is a bit of a hack needed to "shortcut" the exception
                         # handling if we're within the same loop - there's no need to wrap and
                         # unwrap the exception and it just adds unnecessary traceback spam.
-                        return res
+
+                        # TODO(erikbern): I don't this should ever happen other than in weird cases
+                        # like how we set the thread loop for pytest to the one in synchronicity
+                        # during Modal tests
+
+                        async def unwrap_coro():
+                            return self._translate(await res, interface)
+
+                        return unwrap_coro()
+
                     coro = self._run_function_async(res, interface)
                     coro = unwrap_coro_exception(coro)
                     return coro

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -294,10 +294,9 @@ class Synchronizer:
                 elif runtime_interface == Interface.BLOCKING:
                     return self._run_generator_sync(res, interface)
             else:
-                if callable(res):
+                if inspect.isfunction(res):
                     # TODO: this is needed for decorator wrappers that returns functions
                     # Maybe a bit of a hacky special case that deserves its own decorator
-
                     @functools.wraps(res)
                     def f_wrapped(*args, **kwargs):
                         return self._translate_out(res(*args, **kwargs), interface)

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -378,9 +378,9 @@ class Synchronizer:
             setattr(object, _MARKED_ATTR, str(uuid.uuid4()))
         object_id = dct[_MARKED_ATTR]
         if object_id not in self._marked:
-            self._marked[object_id] = dict([
-                (interface, self._wrap(object, interface)) for interface in Interface
-            ])
+            self._marked[object_id] = dict(
+                [(interface, self._wrap(object, interface)) for interface in Interface]
+            )
         return object
 
     def get(self, object, interface):

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -291,6 +291,16 @@ class Synchronizer:
                 elif runtime_interface == Interface.BLOCKING:
                     return self._run_generator_sync(res, interface)
             else:
+                if callable(res):
+                    # TODO: this is needed for decorator wrappers that returns functions
+                    # Maybe a bit of a hacky special case that deserves its own decorator
+
+                    @functools.wraps(res)
+                    def f_wrapped(*args, **kwargs):
+                        return self._translate_out(res(*args, **kwargs), interface)
+
+                    return f_wrapped
+
                 return self._translate_out(res, interface)
 
         setattr(f_wrapped, _WRAPPED_ATTR, True)

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -37,17 +37,18 @@ class Synchronizer:
         self._marked = {}  # classes/function we have pre-wrapped
         atexit.register(self._close_loop)
 
+    _PICKLE_ATTRS = [
+        "_multiwrap_warning",
+        "_async_leakage_warning",
+        "_marked",
+    ]
+
     def __getstate__(self):
-        return {
-            "_multiwrap_warning": self._multiwrap_warning,
-            "_async_leakage_warning": self._async_leakage_warning,
-            "_marked": marked,
-        }
+        return dict([(attr, getattr(self, attr)) for attr in self._PICKLE_ATTRS])
 
     def __setstate__(self, d):
-        self._multiwrap_warning = d["_multiwrap_warning"]
-        self._async_leakage_warning = d["_async_leakage_warning"]
-        self._marked = d["_marked"]
+        for attr in self._PICKLE_ATTRS:
+            setattr(self, attr, d[attr])
 
     def _start_loop(self, loop):
         if self._loop and self._loop.is_running():

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -44,7 +44,6 @@ class Synchronizer:
     _PICKLE_ATTRS = [
         "_multiwrap_warning",
         "_async_leakage_warning",
-        "_marked",
     ]
 
     def __getstate__(self):

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -353,7 +353,7 @@ class Synchronizer:
     def _wrap(self, object, interface):
         if inspect.isclass(object):
             new_object = self._wrap_class(object, interface)
-        elif callable(object):  # TODO: don't include objects with a __call__ method
+        elif inspect.isfunction(object):
             new_object = self._wrap_callable(object, interface)
         else:
             raise Exception("Argument %s is not a class or a callable" % object)

--- a/synchronicity/synchronizer.py
+++ b/synchronicity/synchronizer.py
@@ -315,9 +315,11 @@ class Synchronizer:
     # New interface that doesn't mutate objects
 
     def mark(self, object):
-        for interface in Interface:
-            self._marked[(object, interface)] = self._wrap(object, interface)
+        if object not in self._marked:
+            self._marked[object] = dict([
+                (interface, self._wrap(object, interface)) for interface in Interface
+            ])
         return object
 
     def get(self, object, interface):
-        return self._marked[(object, interface)]
+        return self._marked[object][interface]

--- a/test/generators_test.py
+++ b/test/generators_test.py
@@ -29,7 +29,7 @@ def test_generator_order_sync():
 
 async def async_bidirectional_producer(i):
     j = yield i
-    assert j == i ** 2
+    assert j == i**2
 
 
 @pytest.mark.asyncio

--- a/test/mark_test.py
+++ b/test/mark_test.py
@@ -1,0 +1,12 @@
+from synchronicity import Synchronizer, Interface
+
+
+def test_function_sync():
+    s = Synchronizer()
+
+    @s.mark
+    async def f(x):
+        return x**2
+
+    f_blocking = s.get(f, Interface.BLOCKING)
+    assert f_blocking(42) == 1764

--- a/test/metaclass_test.py
+++ b/test/metaclass_test.py
@@ -5,6 +5,7 @@ from synchronicity import Synchronizer, Interface
 
 SLEEP_DELAY = 0.1
 
+
 def test_metaclass():
     s = Synchronizer()
 
@@ -16,12 +17,12 @@ def test_metaclass():
     class ObjectBase(metaclass=ObjectMetaclass):
         async def square(self, x):
             await asyncio.sleep(SLEEP_DELAY)
-            return x ** 2
+            return x**2
 
     class ObjectDerived(ObjectBase):
         async def cube(self, x):
             await asyncio.sleep(SLEEP_DELAY)
-            return x ** 3
+            return x**3
 
     # Test base class
     base = ObjectBase()

--- a/test/pickle_test.py
+++ b/test/pickle_test.py
@@ -8,7 +8,7 @@ s = Synchronizer()
 @s
 class PicklableClass:
     async def f(self, x):
-        return x ** 2
+        return x**2
 
 
 def test_pickle():

--- a/test/synchronicity_test.py
+++ b/test/synchronicity_test.py
@@ -11,7 +11,7 @@ SLEEP_DELAY = 0.1
 
 async def f(x):
     await asyncio.sleep(SLEEP_DELAY)
-    return x ** 2
+    return x**2
 
 
 async def f2(fn, x):
@@ -98,7 +98,7 @@ def test_function_many_parallel_sync_futures():
     futs = [g(i, _future=True) for i in range(100)]
     assert isinstance(futs[0], concurrent.futures.Future)
     assert time.time() - t0 < SLEEP_DELAY
-    assert [fut.result() for fut in futs] == [z ** 2 for z in range(100)]
+    assert [fut.result() for fut in futs] == [z**2 for z in range(100)]
     assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
 
 
@@ -110,7 +110,7 @@ async def test_function_many_parallel_async():
     coros = [g(i) for i in range(100)]
     assert inspect.iscoroutine(coros[0])
     assert time.time() - t0 < SLEEP_DELAY
-    assert await asyncio.gather(*coros) == [z ** 2 for z in range(100)]
+    assert await asyncio.gather(*coros) == [z**2 for z in range(100)]
     assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
 
 
@@ -169,7 +169,6 @@ def test_function_raises_baseexc_sync():
         f_raises_baseexc_s = s(f_raises_baseexc)
         f_raises_baseexc_s()
     assert SLEEP_DELAY < time.time() - t0 < 2 * SLEEP_DELAY
-
 
 
 async def gen(n):
@@ -272,7 +271,7 @@ class MyClass(Base):
 
     async def get_result(self):
         ret = await self._task
-        return ret ** 2
+        return ret**2
 
     async def __aenter__(self):
         await asyncio.sleep(SLEEP_DELAY)

--- a/test/tracebacks_test.py
+++ b/test/tracebacks_test.py
@@ -101,7 +101,7 @@ async def test_async_to_async_ctx_mgr():
 def test_recursive():
     s = Synchronizer()
 
-    @s
+    @s.mark
     async def f(n):
         if n == 0:
             raise CustomException("boom!")
@@ -109,5 +109,6 @@ def test_recursive():
             return await f(n - 1)
 
     with pytest.raises(CustomException) as excinfo:
-        f(10)
+        f_blocking = s.get_blocking(f)
+        f_blocking(10)
     check_traceback(excinfo.value)

--- a/test/tracebacks_test.py
+++ b/test/tracebacks_test.py
@@ -106,7 +106,7 @@ def test_recursive():
         if n == 0:
             raise CustomException("boom!")
         else:
-            return await f(n-1)
+            return await f(n - 1)
 
     with pytest.raises(CustomException) as excinfo:
         f(10)

--- a/test/warnings_test.py
+++ b/test/warnings_test.py
@@ -5,7 +5,7 @@ from synchronicity import Synchronizer
 
 
 def f(x):
-    return x ** 2
+    return x**2
 
 
 def test_multiwrap_warning(recwarn):


### PR DESCRIPTION
This is needed in order to runtime-translate classes/functions returned from internal code

This pretty much only adds features and doesn't change existing features. The new features (`@synchronizer.mark` et al) are quite experimental and may not have the most user-friendly API. In particular I've noticed various things, eg – if you pass it objects of the wrong type, it can get stuck, and other things.

However, a lot of the existing stuff is somewhat at odds with the approach I want to go in. The new API essentially means all calls go through a "barrier" once. A bunch of stuff that was previously expected (synchronized code calling synchronized code intra-thread) is now actually something _bad_ we should look out for. But I can't really catch those things unless I remove support for a bunch of old things.

For this reason, I'm going to merge this even though the new stuff is pretty unstable – it will be the last version of synchronicity in the 0.1.* series. I'll remove a bunch of old stuff and clean things up and publish a 0.2.0 hopefully shortly, which will not be backwards compatible.

Writing down a couple of 0.2.0 TODOs here, will copy over later:
* [ ] Warn when the thread loop is the same when crossing the barrier
* [ ] Warn when the thread loop is not the same when calling internal code (this requires modifying the wrapped class during `@synchronizer.mark` but the modification is trivial
* [ ] Have a special method for wrapping decorators
