### PR TITLE
Breaking test for instance translations

### DIFF
--- a/test/translate_test.py
+++ b/test/translate_test.py
@@ -1,0 +1,26 @@
+import asyncio
+import pytest
+
+from synchronicity import Synchronizer
+
+
+def test_translate():
+    s = Synchronizer()
+
+    @s.mark
+    class Foo:
+        pass
+
+    @s.mark
+    class FooProvider:
+        def __init__(self):
+            self.foo = Foo()
+
+        def get(self):
+            return self.foo
+
+    FooProvider_blocking = s.get_blocking(FooProvider)
+    foo_provider_blocking = FooProvider_blocking()
+    foo1 = foo_provider_blocking.get()
+    foo2 = foo_provider_blocking.get()
+    assert foo1 == foo2


### PR DESCRIPTION
Figured out the bug in 0.1.7 and was able to write a simple test case for it. It has to do with how `_translate_out` creates new objects every time, which messes up the object identity.

The correct solution is probably to do something like what we do with classes and store references to instances on creation so that they are consistent.