### PR TITLE
bump to 0.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
 from setuptools import setup
 
-setup(name="synchronicity", version="0.1.11")
+setup(name="synchronicity", version="0.2.0")


### PR DESCRIPTION
This breaks a lot of behavior in 0.1.x with regards to class hierarchy and other things

It still preserves the old interface `@synchronizer(z)` which will return something with the "auto" interface. Maybe we'll remove that later in 0.3.0